### PR TITLE
Update for Odoo version 8

### DIFF
--- a/__openerp__.py
+++ b/__openerp__.py
@@ -18,5 +18,5 @@
     'description': "Makes binary image fields display in list and tree views",
     'category': 'Hidden',
     'depends': ['web'],
-    'js': ['static/src/js/view_list.js'],
+    'data': ['views/listview_images_assets.xml'],
 }

--- a/static/src/js/view_list.js
+++ b/static/src/js/view_list.js
@@ -16,8 +16,7 @@ openerp.listview_images = function(instance) {
 
             if (value && value.substr(0, 10).indexOf(' ') == -1) {
 		/* Data inline */
-		/* FIXME: can we get the mimetype from the data? */
-		img_url = "data:image/png;base64," + value;
+		img_url = "data:application/octet-stream;base64," + value;
 	    } else {
 		/* Data by URI (presumably slow) */
 		img_url = instance.session.url('/web/binary/image', {model: options.model, field: this.id, id: options.id});

--- a/views/listview_images_assets.xml
+++ b/views/listview_images_assets.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<openerp>
+    <data>
+        <template id="assets_backend" name="listview_images_assets" inherit_id="web.assets_backend">
+            <xpath expr="." position="inside">
+                <script type="text/javascript" src="/listview_images/static/src/js/view_list.js"></script>
+            </xpath>
+        </template>
+    </data>
+</openerp>


### PR DESCRIPTION
o In Odoo 8 javascript files (and other web assets like CSS) must be
  specified in a special xml file
o Change mime type of image instead of hard-coding an image type
